### PR TITLE
Expose code as an AMD module

### DIFF
--- a/lib/testdouble-chai.js
+++ b/lib/testdouble-chai.js
@@ -1,4 +1,4 @@
-module.exports = function(testdouble) {
+function tdChai(testdouble) {
   var td = testdouble;
 
   return function(chai, utils) {
@@ -75,3 +75,17 @@ module.exports = function(testdouble) {
     }
   };
 };
+
+(function(root, name) {
+  if (typeof module !== 'undefined') {
+    module.exports = tdChai;
+  } else if (typeof define === 'function') {
+    define(name, [], function() {
+      return {
+        'default': tdChai
+      };
+    });
+  } else {
+    root[name] = tdChai;
+  }
+})(this, 'testdouble-chai');


### PR DESCRIPTION
I wanted to use this with Ember but without an AMD module, there wasn't a good way to import it.  This change just avoids _only_ exporting through `module.exports` and adds the ability to export that or an AMD module (or a global variable, if neither of those options are available).

I didn't explicit add an automated test for the AMD export, but I was able to pull it into Ember with these changes present.
