### PR TITLE
Verify TestDouble call counts

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es2021": true,
+    "node": true,
+    "mocha": true
+  },
+  "extends": [
+    "eslint:recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 13
+  },
+  "rules": {
+    "array-bracket-spacing": [ "error", "always", { "objectsInArrays": true, "arraysInArrays": true } ], 
+    "block-spacing": "error",
+    "curly": "error",
+    "func-call-spacing": ["error", "never"],
+    "indent": ["error", 2 ],
+    "linebreak-style": ["error", "unix"],
+    "max-len": ["error", {"code": 120, "ignoreUrls": true, "ignoreStrings": true } ],
+    "object-curly-spacing": ["error", "always", { "arraysInObjects": true, "objectsInObjects": true } ],
+    "quotes": ["error", "double", {"avoidEscape": true } ],
+    "semi": ["error", "always"],
+    "space-before-function-paren": ["error", "always"]    
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # testdouble-chai
 
-This is a tiny library that adds `.called` and `.calledWith` assertions to
+This is a tiny library that adds `.called`, `.calledWith`, and `.calledTimes` assertions to
 [chai](http://chaijs.com/) for use with
 [testdouble.js](https://github.com/testdouble/testdouble.js). These assertions
 can be used as syntactic sugar over the `testdouble.verify` function. Here are
@@ -25,6 +25,21 @@ it("can tell you if a testdouble object was called a certain way", function() {
   expect(td).to.have.been.calledWith("hi");  // instead of `verify(td("hi"))`!
 });
 ```
+
+or for call counts:
+
+```javascript 
+it("can tell you if a testdouble object was called multiple times", function() {
+  var td = testdouble.function();
+  td("hi")
+  td("secondCall")
+  expect(td).to.have.been.calledTimes(2); // instead of `verify(td(), { ignoreExtraArgs: true, times: 2 })`
+})
+```
+
+In addition, `.calledOnce`, `.calledTwice`, and `.calledThrice` can be used 
+in place of `.calledTimes(1)`, `.calledTimes(2)`, and `.calledTimes(3)`, 
+respectively.
 
 ## Setup
 

--- a/lib/testdouble-chai.js
+++ b/lib/testdouble-chai.js
@@ -1,100 +1,81 @@
-function tdChai(testdouble) {
+function tdChai (testdouble) {
   var td = testdouble;
 
-  return function(chai, utils) {
-    utils.addProperty(chai.Assertion.prototype, "called", called_handler);
-    utils.addMethod(chai.Assertion.prototype, "calledWith", called_with_handler);
-    utils.addMethod(chai.Assertion.prototype, "calledTimes", called_times_handler);
-    utils.addProperty(chai.Assertion.prototype, "calledOnce", called_once_handler);
-    utils.addProperty(chai.Assertion.prototype, "calledTwice", called_twice_handler);  
-    utils.addProperty(chai.Assertion.prototype, "calledThrice", called_thrice_handler);
+  return function (chai, utils) {
+    utils.addProperty(chai.Assertion.prototype, "called", calledHandler);
+    utils.addMethod(chai.Assertion.prototype, "calledWith", calledWithHandler);
+    utils.addMethod(chai.Assertion.prototype, "calledTimes", calledTimesHandler);
+    utils.addProperty(chai.Assertion.prototype, "calledOnce", calledOnceHandler);
+    utils.addProperty(chai.Assertion.prototype, "calledTwice", calledTwiceHandler);  
+    utils.addProperty(chai.Assertion.prototype, "calledThrice", calledThriceHandler);
     
-    function called_handler () {
-      assertSubjectCalled.call(this);
-    }
+    function verify ({ subject, args, times }) {
+      const options = { 
+        ignoreExtraArgs: !args,  
+        ... (typeof times === "undefined" ? {} : { times })
+      };
 
-    function assertSubjectCalled() { 
-      const subject = this._obj;
       let verified = false;
 
       try {
-        td.verify(subject.apply(subject, []), { ignoreExtraArgs: true });
-        verified = true;       
-      } catch(err) {
-        if (/No test double invocation detected/.test(err.message)) {
-          throw new Error(subject + " does not appear to be a testdouble object.");
-        }
-      }      
-
-      this.assert(verified,
-        `expected ${subject} to have been called, but it was not.`,
-        `expected ${subject} not to have been called, but it was.`);
-    }
-
-    function called_with_handler(...expectedArguments) {
-      assertSubjectCalledWithArgs.call(this, expectedArguments);
-    }
-
-    function assertSubjectCalledWithArgs(expectedArguments) {
-      const subject = this._obj;
-      let verified = false;
-
-      try {
-        td.verify(subject.apply(subject, expectedArguments), { ignoreExtraArgs: false });
+        td.verify(subject.apply(subject, args || []), options);
         verified = true;
-      } catch(err) {
+      } catch (err) {
         if (/No test double invocation detected/.test(err.message)) {
           throw new Error(subject + " does not appear to be a testdouble object.");
         }
       }
       
-      const  { callCount, calls: [ { args: actual_args  } = { args: [] } ] } = td.explain(subject);
-      const wasCalled = Boolean(callCount);
+      const  { callCount: actualCallCount, calls: [ { args: actualArgs  } = { args: [] } ] } = td.explain(subject);
+      const wasCalled = Boolean(actualCallCount);
+
+      return { verified, wasCalled, actualCallCount, actualArgs };
+    }
+
+
+    function calledHandler () {
+      const subject = this._obj;
+
+      const { verified } = verify({ subject });
+  
+      this.assert(verified,
+        `expected ${subject} to have been called, but it was not.`,
+        `expected ${subject} not to have been called, but it was.`);
+    }
+
+
+    function calledWithHandler (...expectedArgs) {
+      const subject = this._obj;
+      const { verified, actualArgs, wasCalled } = verify({ subject, args: expectedArgs });
       
       const failure_message = `expected ${subject} to have been called with #{exp}, ` +
         (wasCalled ?  "but it received #{act}." : "but it was not called.");
       const inverted_failure_message = `expected ${subject} not to have been called with #{exp}, but it was.`;
 
-
       this.assert(verified,
         failure_message,
         inverted_failure_message,
-        expectedArguments,
-        actual_args,
+        expectedArgs,
+        actualArgs,
         true);   
     }
 
-    function called_times_handler(expectedCallCount) {
-      assertSubjectCalledNTimes.call(this, expectedCallCount);
+    function calledOnceHandler () {
+      calledTimesHandler.call(this, 1);
     }
 
-    function called_once_handler() {
-      assertSubjectCalledNTimes.call(this, 1);
+    function calledTwiceHandler () {
+      calledTimesHandler.call(this, 2);
     }
 
-    function called_twice_handler() {
-      assertSubjectCalledNTimes.call(this, 2);
+    function calledThriceHandler () {
+      calledTimesHandler.call(this, 3);
     }
 
-    function called_thrice_handler() {
-      assertSubjectCalledNTimes.call(this, 3);
-    }
-
-    function assertSubjectCalledNTimes(expectedCallCount) {
+    function calledTimesHandler (expectedCallCount) {
       const subject = this._obj;
-      let verified = false;
 
-      try {
-        td.verify(subject.apply(subject, []), { ignoreExtraArgs: true, times: expectedCallCount });
-        verified = true;
-      } catch(err) {
-        if (/No test double invocation detected/.test(err.message)) {
-          throw new Error(subject + " does not appear to be a testdouble object.");
-        }
-      }      
-
-      const  { callCount: actualCallCount } = td.explain(subject);
-      const wasCalled = Boolean(actualCallCount);
+      const { verified, actualCallCount, wasCalled } = verify({ subject, times: expectedCallCount });
 
       const failure_message = (expectedCallCount === 0 
         ? `expected ${subject} not to have been called (to have been called zero times), ` 
@@ -114,20 +95,16 @@ function tdChai(testdouble) {
         expectedCallCount,
         actualCallCount,
         false);  
-  
     }
-
-
-    
   };
 }
 
 /* global define */
-(function(root, name) {
+(function (root, name) {
   if (typeof module !== "undefined") {
     module.exports = tdChai;
   } else if (typeof define === "function") {
-    define(name, [], function() {
+    define(name, [], function () {
       return {
         "default": tdChai
       };

--- a/lib/testdouble-chai.js
+++ b/lib/testdouble-chai.js
@@ -4,88 +4,135 @@ function tdChai(testdouble) {
   return function(chai, utils) {
     utils.addProperty(chai.Assertion.prototype, "called", called_handler);
     utils.addMethod(chai.Assertion.prototype, "calledWith", called_with_handler);
-
-    function called_handler() {
-      enact_expectation.call(this, {
-        subject: this._obj,
-        did_want_args: false,
-        display_diff: false
-      });
+    utils.addMethod(chai.Assertion.prototype, "calledTimes", called_times_handler);
+    utils.addProperty(chai.Assertion.prototype, "calledOnce", called_once_handler);
+    utils.addProperty(chai.Assertion.prototype, "calledTwice", called_twice_handler);  
+    utils.addProperty(chai.Assertion.prototype, "calledThrice", called_thrice_handler);
+    
+    function called_handler () {
+      assertSubjectCalled.call(this);
     }
 
-    function called_with_handler() {
-      enact_expectation.call(this, {
-        subject: this._obj,
-        expected_args: [].slice.call(arguments),
-        did_want_args: true,
-        display_diff: true
-      });
-    }
-
-
-    function enact_expectation(opts) {
-      var subject        = opts.subject,
-          expected_args  = opts.expected_args,
-          did_want_args  = opts.did_want_args,
-          display_diff   = opts.display_diff,
-          actual_args    = [],
-          verified       = false,
-          last_call      = null,
-          explanation;
+    function assertSubjectCalled() { 
+      const subject = this._obj;
+      let verified = false;
 
       try {
-        td.verify(subject.apply(subject, expected_args), {ignoreExtraArgs: !did_want_args});
-        verified = true;
+        td.verify(subject.apply(subject, []), { ignoreExtraArgs: true });
+        verified = true;       
       } catch(err) {
-        if (/No test double invocation detected/.test(err.message))
+        if (/No test double invocation detected/.test(err.message)) {
           throw new Error(subject + " does not appear to be a testdouble object.");
-
-        explanation = td.explain(subject);
-        if (explanation.callCount) {
-          last_call = explanation.calls[0];
-          actual_args = last_call.args;
         }
-      }
+      }      
 
       this.assert(verified,
-                  failure_message(subject, did_want_args, !!last_call),
-                  inverted_failure_message(subject, did_want_args),
-                  expected_args,
-                  actual_args,
-                  display_diff);
+        `expected ${subject} to have been called, but it was not.`,
+        `expected ${subject} not to have been called, but it was.`);
+    }
+
+    function called_with_handler(...expectedArguments) {
+      assertSubjectCalledWithArgs.call(this, expectedArguments);
+    }
+
+    function assertSubjectCalledWithArgs(expectedArguments) {
+      const subject = this._obj;
+      let verified = false;
+
+      try {
+        td.verify(subject.apply(subject, expectedArguments), { ignoreExtraArgs: false });
+        verified = true;
+      } catch(err) {
+        if (/No test double invocation detected/.test(err.message)) {
+          throw new Error(subject + " does not appear to be a testdouble object.");
+        }
+      }
+      
+      const  { callCount, calls: [ { args: actual_args  } = { args: [] } ] } = td.explain(subject);
+      const wasCalled = Boolean(callCount);
+      
+      const failure_message = `expected ${subject} to have been called with #{exp}, ` +
+        (wasCalled ?  "but it received #{act}." : "but it was not called.");
+      const inverted_failure_message = `expected ${subject} not to have been called with #{exp}, but it was.`;
+
+
+      this.assert(verified,
+        failure_message,
+        inverted_failure_message,
+        expectedArguments,
+        actual_args,
+        true);   
+    }
+
+    function called_times_handler(expectedCallCount) {
+      assertSubjectCalledNTimes.call(this, expectedCallCount);
+    }
+
+    function called_once_handler() {
+      assertSubjectCalledNTimes.call(this, 1);
+    }
+
+    function called_twice_handler() {
+      assertSubjectCalledNTimes.call(this, 2);
+    }
+
+    function called_thrice_handler() {
+      assertSubjectCalledNTimes.call(this, 3);
+    }
+
+    function assertSubjectCalledNTimes(expectedCallCount) {
+      const subject = this._obj;
+      let verified = false;
+
+      try {
+        td.verify(subject.apply(subject, []), { ignoreExtraArgs: true, times: expectedCallCount });
+        verified = true;
+      } catch(err) {
+        if (/No test double invocation detected/.test(err.message)) {
+          throw new Error(subject + " does not appear to be a testdouble object.");
+        }
+      }      
+
+      const  { callCount: actualCallCount } = td.explain(subject);
+      const wasCalled = Boolean(actualCallCount);
+
+      const failure_message = (expectedCallCount === 0 
+        ? `expected ${subject} not to have been called (to have been called zero times), ` 
+        : `expected ${subject} to have been called #{exp} ${expectedCallCount === 1 ? "time" : "times"}, `) + 
+        ( wasCalled 
+          ? `but it was called #{act} ${actualCallCount === 1 ? "time" : "times"}.`  
+          : "but it was not called.");
+
+      const inverted_failure_message = expectedCallCount === 0 
+        ? `expected ${subject} to have been called (not to have been called 0 times), but in fact it was not called.`
+        : (`expected ${subject} not to have been called #{exp} ${expectedCallCount === 1 ? "time" : "times"}, ` 
+            + (wasCalled ? "but in fact it was." : "but in fact it was not called at all.")); 
+ 
+      this.assert(verified,
+        failure_message,
+        inverted_failure_message,
+        expectedCallCount,
+        actualCallCount,
+        false);  
+  
     }
 
 
-    function failure_message(testdouble, did_want_args, was_called) {
-      var with_args, but;
-
-      with_args = did_want_args? " with #{exp}" : "";
-      but = did_want_args?
-        was_called? "but it received #{act}." : "but it was not called."
-        : "but it was not.";
-
-      return "expected " + testdouble +
-             " to have been called" + with_args + ", " + but;
-    }
-
-    function inverted_failure_message(testdouble, did_want_args) {
-      var with_args = did_want_args? " with #{exp}" : "";
-      return "expected " + testdouble + " not to have been called" +
-             with_args + ", but it was.";
-    }
+    
   };
-};
+}
 
+/* global define */
 (function(root, name) {
-  if (typeof module !== 'undefined') {
+  if (typeof module !== "undefined") {
     module.exports = tdChai;
-  } else if (typeof define === 'function') {
+  } else if (typeof define === "function") {
     define(name, [], function() {
       return {
-        'default': tdChai
+        "default": tdChai
       };
     });
   } else {
     root[name] = tdChai;
   }
-})(this, 'testdouble-chai');
+})(this, "testdouble-chai");

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "homepage": "https://github.com/BaseCase/testdouble-chai",
   "author": "Casey Brant",
   "main": "lib/testdouble-chai.js",
-  "dependencies": {},
   "devDependencies": {
     "chai": ">=3.4.1",
+    "eslint": "^8.5.0",
     "mocha": ">=2.3.3",
     "testdouble": ">=0.6.0"
   },

--- a/test/testdouble-chai_test.js
+++ b/test/testdouble-chai_test.js
@@ -1,118 +1,275 @@
-var td = require('testdouble');
-var chai = require('chai');
+/* eslint-env mocha */
+
+var td = require("testdouble");
+var chai = require("chai");
 var expect = chai.expect;
-var tdChai = require('../lib/testdouble-chai');
+var tdChai = require("../lib/testdouble-chai");
 chai.use(tdChai(td));
 
-
-describe("testdouble-chai", function() {
-  beforeEach(function() {
+describe("testdouble-chai", function () {
+  beforeEach(function () {
     this.subject = td.function("dubs");
   });
 
-  afterEach(function() {
+  afterEach(function () {
     td.reset();
   });
 
-  describe(".called", function() {
-    it("passes if the given testdouble was called with no arguments", function() {
+  describe(".called", function () {
+    it("passes if the given testdouble was called with no arguments", function () {
       this.subject();
+
       expect(this.subject).to.have.been.called;
     });
 
-    it("passes if the given testdouble was called with any arguments", function() {
-      this.subject('hi');
+    it("passes if the given testdouble was called with any arguments", function () {
+      this.subject("hi");
+
       expect(this.subject).to.have.been.called;
     });
 
-    it("fails with an AssertionError if the testdouble was not called", function() {
-      expect(function() {
-        expect(this.subject).to.have.been.called;
-      }.bind(this))
-      .to.throw(chai.AssertionError,
-          "AssertionError: expected " +
-          this.subject +
-          " to have been called, but it was not.");
+    it("fails with an AssertionError if the testdouble was not called", function () {
+      expect(() => { expect(this.subject).to.have.been.called; })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' + 
+        "to have been called, but it was not.");
     });
 
-    it("throws an exception if called on an object that isn't a testdouble", function() {
-      var not_a_testdouble = function() {};
-      not_a_testdouble();
-      expect(function() {
-        expect(not_a_testdouble).to.have.been.called;
-      }.bind(this))
-      .to.throw(Error, not_a_testdouble + " does not appear to be a testdouble object.");
-    });
+    it("throws an exception if called on an object that isn't a testdouble", function () {
+      const notATestDouble = function () {};
+      notATestDouble();
 
-    describe("in a negated assertion chain", function() {
-      it("passes if the testdouble was not called", function() {
-        expect(this.subject).not.to.have.been.called;
-      });
-
-      it("fails if the testdouble was called", function() {
-        this.subject();
-        expect(function() {
-          expect(this.subject).not.to.have.been.called;
-        }.bind(this))
-        .to.throw(chai.AssertionError,
-            "AssertionError: expected " +
-            this.subject +
-            " not to have been called, but it was.");
-      });
+      expect(() => { expect(notATestDouble).to.have.been.called; })
+        .to.throw(Error, "function () {} does not appear to be a testdouble object.");
     });
   });
 
+  describe(".called, in a negated assertion chain", function () {
+    it("passes if the testdouble was not called", function () {
+      expect(this.subject).not.to.have.been.called;
+    });
 
-  describe(".calledWith", function() {
-    it("passes if the given testdouble was called with the given arguments", function() {
+    it("fails if the testdouble was called", function () {
+      this.subject();
+
+      expect(() => { expect(this.subject).not.to.have.been.called; })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' + 
+        "not to have been called, but it was.");
+    });
+  });
+
+  describe(".calledWith", function () {
+    it("passes if the given testdouble was called with the given arguments", function () {
       this.subject("hi");
+
       expect(this.subject).to.have.been.calledWith("hi");
     });
 
-    it("fails if the testdouble was not called", function() {
-      expect(function() {
-        expect(this.subject).to.have.been.calledWith("hi", "bye");
-      }.bind(this))
-      .to.throw(chai.AssertionError,
-          "AssertionError: expected " +
-          this.subject +
-          " to have been called with " +
-          "[ \'hi\', \'bye\' ]," +
-          " but it was not called.");
+    it("fails if the testdouble was not called", function () {
+      expect(() => { expect(this.subject).to.have.been.calledWith("hi", "bye"); })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' + 
+        "to have been called with [ 'hi', 'bye' ], but it was not called.");
     });
 
-    it("fails on expected/actual arguments mismatch, detailing the discrepancies", function() {
+    it("fails on expected/actual arguments mismatch, detailing the discrepancies", function () {
       this.subject("what");
-      expect(function() {
-        expect(this.subject).to.have.been.calledWith("hi", "bye");
-      }.bind(this))
-      .to.throw(chai.AssertionError,
-          "AssertionError: expected " +
-          this.subject +
-          " to have been called with " +
-          "[ \'hi\', \'bye\' ]," +
-          " but it received " +
-          "[ \'what\' ]");
+      
+      expect(() => { expect(this.subject).to.have.been.calledWith("hi", "bye"); })
+        .to.throw(chai.assertionError, 'expected [test double for "dubs"] ' + 
+        "to have been called with [ 'hi', 'bye' ], but it received [ 'what' ].");
+    });
+  });
+
+  describe(".calledWith, in a negated assertion chain", function () {
+    it("passes if the testdouble was not called with the given arguments", function () {
+      this.subject("bye");
+
+      expect(this.subject).not.to.have.been.calledWith("hi");
     });
 
+    it("fails if the testdouble was called with the given arguments", function () {
+      this.subject("bye");
+   
+      expect(() => { expect(this.subject).not.to.have.been.calledWith("bye"); })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' + 
+          "not to have been called with [ 'bye' ], but it was.");
+    });
+  });
 
-    describe("in a negated chain", function() {
-      it("passes if the testdouble was not called with the given arguments", function() {
-        this.subject("bye");
-        expect(this.subject).not.to.have.been.calledWith("hi");
-      });
+  describe(".calledTimes", function () {
+    it("passes if the test double was not called, with calledTimes(0)", function () {
+      expect(this.subject).to.have.been.calledTimes(0);
+    });
 
-      it("fails if the testdouble was called with the given arguments", function() {
-        this.subject("bye");
-        expect(function() {
-          expect(this.subject).not.to.have.been.calledWith("bye");
-        }.bind(this))
-        .to.throw(chai.AssertionError,
-            "AssertionError: expected " +
-            this.subject +
-            " not to have been called with [ \'bye\' ], " +
-            "but it was.");
-      });
+    it("passes if the test double was called once, with calledTimes(1)", function () {
+      this.subject(1);
+
+      expect(this.subject).to.have.been.calledTimes(1);
+    });
+
+    it("passes if the test double was called twice, with calledTimes(2)", function () {
+      this.subject(1);
+      this.subject(2);
+
+      expect(this.subject).to.have.been.calledTimes(2);
+    });
+
+    it("fails if the test double was called less than specified", function () {
+      this.subject(1);
+  
+      expect(() => { expect(this.subject).to.have.been.calledTimes(2); })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' + 
+          "to have been called 2 times, but it was called 1 time.");
+    });
+
+    it("fails if the test double was called more than specified", function () {
+      this.subject(1);
+      this.subject(2);
+      this.subject(3);
+
+      expect(() => { expect(this.subject).to.have.been.calledTimes(2); })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' + 
+          "to have been called 2 times, but it was called 3 times.");
+    });
+
+    it("fails if the test double was called at all, with calledTimes(0)", function () {
+      this.subject(1);
+      
+      expect(() => { expect(this.subject).to.have.been.calledTimes(0); })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' +
+          "not to have been called (to have been called zero times), " +
+          "but it was called 1 time.");
+    });
+  });
+
+  describe(".calledTimes, in a negated assertion chain", function () {
+    it("passes if it is not called the specified number of times", function () {
+      this.subject(1);
+
+      expect(this.subject).not.to.have.been.calledTimes(3);
+    });
+
+    it("fails if it is called the specified number of times", function () {
+      this.subject(1);
+      this.subject(1);
+
+      expect(() => { expect(this.subject).not.to.have.been.calledTimes(2); })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' + 
+          "not to have been called 2 times, but in fact it was.");
+    });
+
+    it("fails if it is not called when it is expected not to be called 0 times", function () {
+      expect(() => {
+        expect(this.subject).not.to.have.been.calledTimes(0);
+      })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' +
+          "to have been called (not to have been called 0 times), but in fact it was not called.");
+    });
+  });
+
+  describe(".calledOnce", function () {
+    it("passes when the test double is called exactly once", function () {
+      this.subject(1);
+
+      expect(this.subject).to.have.been.calledOnce;
+    });
+
+    it("fails when the test double is not called exactly once", function () {
+      this.subject(1);
+      this.subject(1);
+
+      expect(() => { expect(this.subject).to.have.been.calledOnce; })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] '+
+          "to have been called 1 time, but it was called 2 times.");
+    });
+  });
+
+  describe(".calledOnce, in a negated assertion chain", function () {
+    it("fails when the test double is called exactly once", function () {
+      this.subject(1);
+
+      expect(() => { expect(this.subject).not.to.have.been.calledOnce; })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' +
+          "not to have been called 1 time, but in fact it was.");
+    });
+
+    it("passes when the test double is not called exactly once", function () {
+      this.subject(1);
+      this.subject(1);
+
+      expect(this.subject).not.to.have.been.calledOnce;
+    });
+  });
+
+  describe(".calledTwice", function () {
+    it("passes when the test double is called exactly twice", function () {
+      this.subject(1);
+      this.subject(1);
+
+      expect(this.subject).to.have.been.calledTwice;
+    });
+
+    it("fails when the test double is not called exactly twice", function () {
+      this.subject(1);
+      this.subject(1);
+      this.subject(1);
+      
+      expect(() => { expect(this.subject).to.have.been.calledTwice; })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' + 
+          "to have been called 2 times, but it was called 3 times.");
+    });
+  });
+
+  describe(".calledTwice, in a negated assertion chain", function () {
+    it("fails when the test double is called exactly twice", function () {
+      this.subject(1);
+      this.subject(1);
+
+      expect(() => { expect(this.subject).not.to.have.been.calledTwice; })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' + 
+          "not to have been called 2 times, but in fact it was.");
+    });
+
+    it("passes when the test double is not called exactly twice", function () {
+      this.subject(1);
+
+      expect(this.subject).not.to.have.been.calledTwice;
+    });
+  });
+
+  describe(".calledThrice", function () {
+    it("passes when the test double is called exactly three times", function () {
+      this.subject(1);
+      this.subject(1);
+      this.subject(1);
+
+      expect(this.subject).to.have.been.calledThrice;
+    });
+
+    it("fails when the test double is not called exactly three times", function () {
+      this.subject(1);
+
+      expect(() => { expect(this.subject).to.have.been.calledThrice; })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' +
+          "to have been called 3 times, but it was called 1 time.");
+    });
+  });
+
+  describe(".calledThrice, in a negated assertion chain", function () {
+    it("fails when the test double is called exactly three times", function () {
+      this.subject(1);
+      this.subject(1);
+      this.subject(1);
+
+      expect(() => { expect(this.subject).not.to.have.been.calledThrice; })
+        .to.throw(chai.AssertionError, 'expected [test double for "dubs"] ' + 
+          "not to have been called 3 times, but in fact it was.");
+    });
+
+    it("passes when the test double is not called exactly three times", function () {
+      this.subject(1);
+      this.subject(1);
+
+      expect(this.subject).not.to.have.been.calledThrice;
     });
   });
 });


### PR DESCRIPTION
I added code to verify the number of times a test double was called, and brought the existing code up to date with current practices.  I added tests and updated the documentation as well.

If there's something about it you don't like or would prefer done another way, let me know.  I'm not dogmatic, and I'd be happy to change it.